### PR TITLE
Fix #1

### DIFF
--- a/src/components/Cell.vue
+++ b/src/components/Cell.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     <button
       v-show="canEdit"
       @click="emit('toggleState')"
-      class="absolute inset-0"
+      class="absolute top-0 left-0 h-full w-full"
     ></button>
     <div
       v-show="canEdit"


### PR DESCRIPTION
Cell edition on firefox is blocked because inset css rule is not supported, so button have width of 0. 
Solved by using classing top:0; left: 0; width: 100%; height: 100%; styles.